### PR TITLE
Fix Bug

### DIFF
--- a/ngJsTree.js
+++ b/ngJsTree.js
@@ -137,7 +137,12 @@
                     if (attrs.tree) {
                         if (attrs.tree.indexOf('.') !== -1) {
                             var split = attrs.tree.split('.');
-                            scope.tree = scope.$parent[split[0]][split[1]] = elm;
+                            var tree = split.pop();
+                            var context = scope.$parent;
+                            for (var i = 0; i < split.length; i++) {
+                                context = context[split[i]];
+                            }
+                            scope.tree = context[tree] = elm;
                         }
                         else {
                             scope.tree = scope.$parent[attrs.tree] = elm;


### PR DESCRIPTION
Fix a bug , when using namepaced varaibles with more than one " . " .
exmaple:
<div js-tree="..." tree="vm.tree.instance" ></div>
before fixing ,destroy methd override instance into vm.tree instead of vm.tree.instance

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ezraroi/ngjstree/49)
<!-- Reviewable:end -->
