### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ngJsTree
 Angular Directive for the famous [JS Tree] library.
 
 
-##Dependencies
+## Dependencies
 
 
 The ngJsTree depends on the following libraries:
@@ -20,7 +20,7 @@ The ngJsTree depends on the following libraries:
 * JsTree
 
 
-##Install
+## Install
 
 
 You can install the ngJsTree with bower:
@@ -46,7 +46,7 @@ or you can add the ngJsTree.min.js file to your HTML page:
 Add the `ngJsTree` to your module dependencies
 
 
-#Documentation
+# Documentation
 
 
 You can find the JSTree documentation at [this link]


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ezraroi/ngjstree/113)
<!-- Reviewable:end -->
