### PR TITLE
Fix Ajax data source bug

### DIFF
--- a/dist/ngJsTree.js
+++ b/dist/ngJsTree.js
@@ -282,7 +282,7 @@
                     return scope.shouldApply();
                 });
 
-                scope.$watch(getOptions, function () {
+                scope.$watchGroup([ 'treeData', getOptions ], function () {
                     scope.destroy();
                     scope.init();
                 });


### PR DESCRIPTION
When using Ajax Json as data source, the tree will fail to render due to sequential issue. The tree is initialized before the Ajax call is made. The propose change is also watching the 'treeData'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ezraroi/ngjstree/128)
<!-- Reviewable:end -->
