### PR TITLE
Bump angular to 1.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "JsTree"
   ],
   "dependencies": {
-    "angular": "~1.6",
+    "angular": "~1.7",
     "jstree": "~3.3.2"
   },
   "license": "MIT",
@@ -29,10 +29,10 @@
     "README.md"
   ],
   "devDependencies": {
-    "angular-mocks": "~1.6",
+    "angular-mocks": "~1.7",
     "jquery": "~2.1.1"
   },
   "resolutions": {
-    "angular": "1.6.6"
+    "angular": "1.7.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/ezraroi/ngJsTree",
   "dependencies": {
-    "angular": "~1.4",
+    "angular": "~1.7",
     "jstree": "~3.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This is mainly to get rid of a security alert which has been fixed in 1.6.0 https://github.com/angular/angular.js/commit/6476af83cd0418c84e034a955b12a842794385c4

> **WS-2018-0001**
**Vulnerable versions**: < 1.6.0
**Patched version**: 1.6.0
> 
> JSONP allows untrusted resource URLs, which provides a vector for attack by malicious actors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ezraroi/ngjstree/132)
<!-- Reviewable:end -->
