### PR TITLE
create_node with inside option not supported by now

### DIFF
--- a/ngJsTree.js
+++ b/ngJsTree.js
@@ -262,7 +262,7 @@
                         while (blocked) { }
                         blocked = true;
                         var parent = scope.tree.jstree(true).get_node(node.parent);
-                        var res = scope.tree.jstree(true).create_node(parent, node, 'inside', function () {
+                        var res = scope.tree.jstree(true).create_node(parent, node, 'last', function () {
                             blocked = false;
                         });
                         if (!res) {


### PR DESCRIPTION
It's `last` by default.
Check out the docs - https://www.jstree.com/api/#/?q=create_no&f=create_node([par,%20node,%20pos,%20callback,%20is_loaded])

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ezraroi/ngJsTree/140)
<!-- Reviewable:end -->
